### PR TITLE
Изменение версии обертки и описания собираемого пакета

### DIFF
--- a/build/RutokenPkcs11Interop.nuspec
+++ b/build/RutokenPkcs11Interop.nuspec
@@ -2,14 +2,13 @@
 <package>
   <metadata>
     <id>Aktiv.RutokenPkcs11Interop</id>
-    <version>2.1.0</version>
+    <version>2.0.11</version>
     <title>Aktiv.RutokenPkcs11Interop</title>
     <authors>Pavel Khrulev</authors>
     <owners>Pavel Khrulev</owners>
     <projectUrl>https://github.com/pavelkhrulev/RutokenPkcs11Interop</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Rutoken interop API</description>
-    <releaseNotes>Version 2.1.0</releaseNotes>
+    <description>Обертка над функциями расширения библиотеки rtPKC11SECP: https://dev.rutoken.ru/x/KIAw</description>
     <copyright>Copyright 2017-2020</copyright>
     <tags>rutoken pkcs11 library</tags>
     <dependencies>

--- a/build/RutokenPkcs11Interop.nuspec.tmpl
+++ b/build/RutokenPkcs11Interop.nuspec.tmpl
@@ -2,14 +2,14 @@
 <package>
   <metadata>
     <id>Aktiv.RutokenPkcs11Interop</id>
-    <version>2.0.11</version>
+    <version>VERSION</version>
     <title>Aktiv.RutokenPkcs11Interop</title>
     <authors>Pavel Khrulev</authors>
     <owners>Pavel Khrulev</owners>
     <projectUrl>https://github.com/pavelkhrulev/RutokenPkcs11Interop</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Обертка над функциями расширения библиотеки rtPKC11SECP: https://dev.rutoken.ru/x/KIAw</description>
-    <copyright>Copyright 2017-2020</copyright>
+    <copyright>COPYRIGHT</copyright>
     <tags>rutoken pkcs11 library</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.5">

--- a/build/build-nuget.bat
+++ b/build/build-nuget.bat
@@ -17,9 +17,22 @@ copy monoandroid2.3\RutokenPkcs11Interop.dll nuget\lib\monoandroid2.3 || goto :e
 copy xamarinios1.0\RutokenPkcs11Interop.dll nuget\lib\xamarinios1.0 || goto :error
 copy xamarinmac2.0\RutokenPkcs11Interop.dll nuget\lib\xamarinmac2.0 || goto :error
 
+@rem prepare spec file
+set dllfile= nuget\lib\net45\RutokenPkcs11Interop.dll
+powershell -NoLogo -NoProfile -Command (Get-Item %dllfile%).VersionInfo.FileVersion > tmpFile || goto :error
+set /p version= < tmpFile
+powershell -NoLogo -NoProfile -Command (Get-Item %dllfile%).VersionInfo.LegalCopyright > tmpFile || goto :error
+set /p copyright= < tmpFile
+
+del tmpFile
+
+set tmplfile=RutokenPkcs11Interop.nuspec.tmpl
+set nuspecfile=RutokenPkcs11Interop.nuspec
+powershell -Command "(Get-Content %tmplfile%).replace('VERSION', '%version%').replace('COPYRIGHT', '%copyright%') | Set-Content %nuspecfile%" || goto :error
+
 @rem Create package
-copy RutokenPkcs11Interop.nuspec nuget || goto :error
-nuget pack nuget\RutokenPkcs11Interop.nuspec || goto :error
+move %nuspecfile% nuget || goto :error
+nuget pack nuget\%nuspecfile% || goto :error
 
 @echo *** BUILD NUGET SUCCESSFUL ***
 @endlocal

--- a/src/RutokenPkcs11Interop.Android/RutokenPkcs11Interop/Properties/AssemblyInfo.cs
+++ b/src/RutokenPkcs11Interop.Android/RutokenPkcs11Interop/Properties/AssemblyInfo.cs
@@ -13,5 +13,5 @@ using Android.App;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("9907a0c9-1b2c-470f-a59f-84def58f15fb")]
-[assembly: AssemblyVersion("2.1.0")]
-[assembly: AssemblyFileVersion("2.1.0")]
+[assembly: AssemblyVersion("2.0.11")]
+[assembly: AssemblyFileVersion("2.0.11")]

--- a/src/RutokenPkcs11Interop.Android/RutokenPkcs11Interop/Properties/AssemblyInfo.cs
+++ b/src/RutokenPkcs11Interop.Android/RutokenPkcs11Interop/Properties/AssemblyInfo.cs
@@ -3,15 +3,5 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Android.App;
 
-[assembly: AssemblyTitle("RutokenPkcs11Interop")]
 [assembly: AssemblyDescription("Managed .NET wrapper for unmanaged Rutoken PKCS#11 library (Android version)")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Aktiv")]
-[assembly: AssemblyProduct("RutokenPkcs11Interop")]
-[assembly: AssemblyCopyright("Copyright 2017-2020")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-[assembly: ComVisible(false)]
 [assembly: Guid("9907a0c9-1b2c-470f-a59f-84def58f15fb")]
-[assembly: AssemblyVersion("2.0.11")]
-[assembly: AssemblyFileVersion("2.0.11")]

--- a/src/RutokenPkcs11Interop.Android/RutokenPkcs11Interop/RutokenPkcs11Interop.csproj
+++ b/src/RutokenPkcs11Interop.Android/RutokenPkcs11Interop/RutokenPkcs11Interop.csproj
@@ -45,6 +45,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\RutokenPkcs11Interop\RutokenPkcs11Interop\Properties\AssemblyInfoCommon.cs">
+      <Link>Properties\AssemblyInfoCommon.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/RutokenPkcs11Interop.NetStandard/RutokenPkcs11Interop/Properties/AssemblyInfo.cs
+++ b/src/RutokenPkcs11Interop.NetStandard/RutokenPkcs11Interop/Properties/AssemblyInfo.cs
@@ -11,5 +11,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("b6214ac7-1d33-463c-8bc1-0b4f6dbefe41")]
-[assembly: AssemblyVersion("2.1.0")]
-[assembly: AssemblyFileVersion("2.1.0")]
+[assembly: AssemblyVersion("2.0.11")]
+[assembly: AssemblyFileVersion("2.0.11")]

--- a/src/RutokenPkcs11Interop.NetStandard/RutokenPkcs11Interop/Properties/AssemblyInfo.cs
+++ b/src/RutokenPkcs11Interop.NetStandard/RutokenPkcs11Interop/Properties/AssemblyInfo.cs
@@ -1,15 +1,5 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyTitle("RutokenPkcs11Interop")]
 [assembly: AssemblyDescription("Managed .NET wrapper for unmanaged Rutoken PKCS#11 library (NetStandard version)")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Aktiv")]
-[assembly: AssemblyProduct("RutokenPkcs11Interop")]
-[assembly: AssemblyCopyright("Copyright 2017-2020")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-[assembly: ComVisible(false)]
 [assembly: Guid("b6214ac7-1d33-463c-8bc1-0b4f6dbefe41")]
-[assembly: AssemblyVersion("2.0.11")]
-[assembly: AssemblyFileVersion("2.0.11")]

--- a/src/RutokenPkcs11Interop.NetStandard/RutokenPkcs11Interop/RutokenPkcs11Interop.csproj
+++ b/src/RutokenPkcs11Interop.NetStandard/RutokenPkcs11Interop/RutokenPkcs11Interop.csproj
@@ -90,6 +90,10 @@
     <Compile Include="..\..\RutokenPkcs11Interop\RutokenPkcs11Interop\Settings.cs">
       <Link>Settings.cs</Link>
     </Compile>
+    
+    <Compile Include="..\..\RutokenPkcs11Interop\RutokenPkcs11Interop\Properties\AssemblyInfoCommon.cs">
+      <Link>Properties\AssemblyInfoCommon.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
 

--- a/src/RutokenPkcs11Interop.iOS/RutokenPkcs11Interop/Properties/AssemblyInfo.cs
+++ b/src/RutokenPkcs11Interop.iOS/RutokenPkcs11Interop/Properties/AssemblyInfo.cs
@@ -1,15 +1,5 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyTitle("RutokenPkcs11Interop")]
 [assembly: AssemblyDescription("Managed .NET wrapper for unmanaged Rutoken PKCS#11 library (iOS version)")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Aktiv")]
-[assembly: AssemblyProduct("RutokenPkcs11Interop")]
-[assembly: AssemblyCopyright("Copyright 2017-2020")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-[assembly: ComVisible(false)]
 [assembly: Guid("50c7b8c9-e664-45af-b88e-0c9b8b9c1be1")]
-[assembly: AssemblyVersion("2.0.11")]
-[assembly: AssemblyFileVersion("2.0.11")]

--- a/src/RutokenPkcs11Interop.iOS/RutokenPkcs11Interop/Properties/AssemblyInfo.cs
+++ b/src/RutokenPkcs11Interop.iOS/RutokenPkcs11Interop/Properties/AssemblyInfo.cs
@@ -11,5 +11,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("50c7b8c9-e664-45af-b88e-0c9b8b9c1be1")]
-[assembly: AssemblyVersion("2.1.0")]
-[assembly: AssemblyFileVersion("2.1.0")]
+[assembly: AssemblyVersion("2.0.11")]
+[assembly: AssemblyFileVersion("2.0.11")]

--- a/src/RutokenPkcs11Interop.iOS/RutokenPkcs11Interop/RutokenPkcs11Interop.csproj
+++ b/src/RutokenPkcs11Interop.iOS/RutokenPkcs11Interop/RutokenPkcs11Interop.csproj
@@ -38,6 +38,9 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\RutokenPkcs11Interop\RutokenPkcs11Interop\Properties\AssemblyInfoCommon.cs">
+      <Link>Properties\AssemblyInfoCommon.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/RutokenPkcs11Interop/RutokenPkcs11Interop/Properties/AssemblyInfo.cs
+++ b/src/RutokenPkcs11Interop/RutokenPkcs11Interop/Properties/AssemblyInfo.cs
@@ -12,5 +12,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("84987be4-7ac6-4430-bf04-80689ebd22a3")]
-[assembly: AssemblyVersion("2.1.0")]
-[assembly: AssemblyFileVersion("2.1.0")]
+[assembly: AssemblyVersion("2.0.11")]
+[assembly: AssemblyFileVersion("2.0.11")]

--- a/src/RutokenPkcs11Interop/RutokenPkcs11Interop/Properties/AssemblyInfo.cs
+++ b/src/RutokenPkcs11Interop/RutokenPkcs11Interop/Properties/AssemblyInfo.cs
@@ -1,16 +1,5 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyTitle("RutokenPkcs11Interop")]
 [assembly: AssemblyDescription("Managed .NET wrapper for unmanaged Rutoken PKCS#11 library")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Aktiv")]
-[assembly: AssemblyProduct("RutokenPkcs11Interop")]
-[assembly: AssemblyCopyright("Copyright 2017-2020")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-[assembly: ComVisible(false)]
 [assembly: Guid("84987be4-7ac6-4430-bf04-80689ebd22a3")]
-[assembly: AssemblyVersion("2.0.11")]
-[assembly: AssemblyFileVersion("2.0.11")]

--- a/src/RutokenPkcs11Interop/RutokenPkcs11Interop/Properties/AssemblyInfoCommon.cs
+++ b/src/RutokenPkcs11Interop/RutokenPkcs11Interop/Properties/AssemblyInfoCommon.cs
@@ -1,0 +1,14 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("RutokenPkcs11Interop")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Aktiv")]
+[assembly: AssemblyProduct("RutokenPkcs11Interop")]
+[assembly: AssemblyCopyright("Copyright 2017-2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+[assembly: ComVisible(false)]
+[assembly: AssemblyVersion("2.0.11")]
+[assembly: AssemblyFileVersion("2.0.11")]

--- a/src/RutokenPkcs11Interop/RutokenPkcs11Interop/RutokenPkcs11Interop.csproj
+++ b/src/RutokenPkcs11Interop/RutokenPkcs11Interop/RutokenPkcs11Interop.csproj
@@ -167,8 +167,10 @@
     <Compile Include="LowLevelAPI81\Pkcs11Extensions.cs" />
     <Compile Include="LowLevelAPI81\RutokenDelegates.cs" />
     <Compile Include="LowLevelAPI81\RutokenNativeMethods.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Settings.cs" />
+    
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfoCommon.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
1. Теперь версия обертки совпадает с версией последней выпущенной для нее библиотеки rtPKCS11ECP + опциональный префикс. 
2. Разбил информацию о сборки библиотеки на общую и специфичную для фреймворка части
3. Получение информации о сборке из File Info